### PR TITLE
feat: expose card_id in /person

### DIFF
--- a/src/models/person.js
+++ b/src/models/person.js
@@ -161,7 +161,8 @@ export const Person = Bookshelf.Model.extend({
 				'ship_id',
 				'status',
 				'home_planet',
-				'is_visible'
+				'is_visible',
+				'card_id'
 			],
 			withRelated: [{
 				ship: qb => qb.column('id', 'name')


### PR DESCRIPTION
Required by Admin Story Tool
> Add CardID to Characters tab as one column (easier to log in as that character)