### PR TITLE
Add scheduled delivery of science test results

### DIFF
--- a/db/redux/misc/index.ts
+++ b/db/redux/misc/index.ts
@@ -67,6 +67,14 @@ sunt eaque dolor id nisi magni.`
 			[SkillLevels.Expert]: Duration.minutes(5),
 		}
 	},
+	{
+		type: 'misc',
+		id: Stores.TagUidToArtifactCatalogId,
+		tagUidToArtifactCatalogId: {
+			// TODO: Fill this with actual data
+			"ABCDEF123456": "BEACON-1",
+		}
+	}
 ];
 
 blobs.forEach(saveBlob);

--- a/db/redux/misc/index.ts
+++ b/db/redux/misc/index.ts
@@ -69,6 +69,22 @@ sunt eaque dolor id nisi magni.`
 	},
 	{
 		type: 'misc',
+		id: Stores.ScienceAnalysisTimes,
+		analysis_times: {
+			[SkillLevels.Novice]: Duration.minutes(5),
+			[SkillLevels.Master]: Duration.minutes(2),
+			[SkillLevels.Expert]: Duration.seconds(15),
+			// A550 power bank thingy that reduces science analysis time when in a plugged in state
+			a550_time_reduction: Duration.minutes(15)
+		}
+	},
+	{
+		type: 'misc',
+		id: Stores.ScienceAnalysisInProgress,
+		analysis_in_progress: []
+	},
+	{
+		type: 'misc',
 		id: Stores.TagUidToArtifactCatalogId,
 		tagUidToArtifactCatalogId: {
 			// TODO: Fill this with actual data

--- a/src/models/artifact.js
+++ b/src/models/artifact.js
@@ -32,6 +32,7 @@ const artifactWithRelated = [
 /**
  * @typedef Artifact
  * @property {integer} id - ID
+ * @property {string} catalog_id - Catalog ID
  * @property {string} name.required - Name
  * @property {string} discovered_by - Name of the person who discovered this artifact
  * @property {string} discovered_at - Name of the location where this artifact was discovered

--- a/src/routes/person.js
+++ b/src/routes/person.js
@@ -90,14 +90,12 @@ router.get('/:id', handleAsyncErrors(async (req, res) => {
 	if (isHackerLogin) {
 		const hacker = await Person.forge({ id: hackerId }).fetchWithRelated();
 		// Get the hacking detection time based on the hacker's skill level
-		const [detectionTimeMs] = await Promise.all([
-			await getHackingDetectionTime(hacker),
-			AuditLogEntry.forge().save({
-				person_id: personId,
-				hacker_id: hackerId,
-				type: 'HACKER_LOGIN'
-			}),
-		]);
+		const detectionTimeMs = getHackingDetectionTime(hacker);
+		await AuditLogEntry.forge().save({
+			person_id: personId,
+			hacker_id: hackerId,
+			type: 'HACKER_LOGIN'
+		});
 
 		const intrusionDetectedMessage = getRandomHackingIntrustionDetectionMessage();
 

--- a/src/rules/science/analysis.js
+++ b/src/rules/science/analysis.js
@@ -1,0 +1,40 @@
+import { interval, saveBlob } from '../helpers';
+import { logger } from '../../logger';
+import { addOperationResultsToArtifactEntry } from '../../utils/science';
+import { OperationResult } from '../../models/tag';
+import { getPath } from '../../store/store';
+
+const POLL_FREQUENCY = 5 * 1000; // 5 seconds
+
+async function processInProgressAnalysis() {
+	const scheduledOperationsBlob = getPath(['data', 'misc', 'science_analysis_in_progress']);
+	const inProgress = scheduledOperationsBlob.analysis_in_progress;
+	if (!Array.isArray(inProgress)) {
+		logger.error('Invalid science_analysis_in_progress blob', inProgress);
+		return;
+	}
+
+	const now = Date.now();
+	const completedOperations = inProgress.filter(({ completes_at }) => completes_at <= now);
+	const remainingOperations = inProgress.filter(({ completes_at }) => completes_at > now);
+
+	if (!completedOperations.length) {
+		return;
+	}
+
+	for (const operation of completedOperations) {
+		const operationResult = await new OperationResult({ id: operation.operation_result_id }).fetch();
+		if (!operationResult) {
+			logger.error('Invalid operation_result_id, not found from db', operation_result_id);
+			continue;
+		}
+		await addOperationResultsToArtifactEntry(operationResult);
+	}
+
+	saveBlob({
+		...scheduledOperationsBlob,
+		analysis_in_progress: remainingOperations,
+	});
+}
+
+interval(processInProgressAnalysis, POLL_FREQUENCY);

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -23,7 +23,7 @@ export const store = configureStore({
  * @param {string[]} path 	array of strings defining the object path to watch, e.g. `['data','task','myid']`
  * @returns					object at the path, or `undefined`
  */
-export function getPath(path: string[]) {
+export function getPath(path: string[]): Record<string, any> | undefined {
 	let o = store.getState();
 	while (path && path.length > 0) {
 		if (o[path[0]]) {

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -3,6 +3,8 @@ import { z } from 'zod';
 
 export const Stores = {
 	HackerDetectionTimes: 'hacker_detection_times',
+	ScienceAnalysisTimes: 'science_analysis_times',
+	ScienceAnalysisInProgress: 'science_analysis_in_progress',
 	TagUidToArtifactCatalogId: 'tag_uid_to_artifact_catalog_id',
 } as const;
 
@@ -16,3 +18,31 @@ export const HackerDetectionTimes = z.object({
 	}),
 });
 export type HackerDetectionTimes = z.infer<typeof HackerDetectionTimes>;
+
+export const ScienceAnalysisTimes = z.object({
+	type: z.literal('misc'),
+	id: z.literal(Stores.ScienceAnalysisTimes),
+	analysis_times: z.object({
+		[SkillLevels.Novice]: z.number().min(0).int(),
+		[SkillLevels.Master]: z.number().min(0).int(),
+		[SkillLevels.Expert]: z.number().min(0).int(),
+		"a550_time_reduction": z.number().min(0).int(),
+	}),
+});
+export type ScienceAnalysisTimes = z.infer<typeof ScienceAnalysisTimes>;
+
+const AnalysisInProgress = z.object({
+	artifact_catalog_id : z.string(),
+	author_name: z.string(),
+	completes_at: z.number().int(),
+	operation_additional_type: z.string(),
+	operation_result_id: z.number().int().positive(),
+	started_at: z.number().int(),
+});
+
+export const ScienceAnalysisInProgress = z.object({
+	type: z.literal('misc'),
+	id: z.literal(Stores.ScienceAnalysisInProgress),
+	analysis_in_progress: z.array(AnalysisInProgress),
+});
+export type ScienceAnalysisInProgress = z.infer<typeof ScienceAnalysisInProgress>;

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 
 export const Stores = {
 	HackerDetectionTimes: 'hacker_detection_times',
+	TagUidToArtifactCatalogId: 'tag_uid_to_artifact_catalog_id',
 } as const;
 
 export const HackerDetectionTimes = z.object({

--- a/src/utils/groups.ts
+++ b/src/utils/groups.ts
@@ -6,7 +6,7 @@ export const SkillLevels = {
 export type SkillLevel = typeof SkillLevels[keyof typeof SkillLevels];
 
 export function getHighestSkillLevel(person: unknown): SkillLevel {
-	if (typeof person !== 'object' || person === null || !('groups' in person)) {
+	if (typeof person !== 'object' || person === null) {
 		return SkillLevels.Novice;
 	}
 

--- a/src/utils/hacking.ts
+++ b/src/utils/hacking.ts
@@ -28,9 +28,9 @@ export const getRandomHackingIntrustionDetectionMessage = () => {
 	return hackingIntrustionDetectionMessages[randomIndex];
 };
 
-export const getHackingDetectionTime = async (hackerPerson: unknown): Promise<number> => {
+export const getHackingDetectionTime = (hackerPerson: unknown): number => {
 	const skillLevel = getHighestSkillLevel(hackerPerson);
-	const detectionTimesBlob = await getPath(['data', 'misc', Stores.HackerDetectionTimes]);
+	const detectionTimesBlob = getPath(['data', 'misc', Stores.HackerDetectionTimes]);
 	const detectionTimes = HackerDetectionTimes.safeParse(detectionTimesBlob);
 	if (!detectionTimes.success) {
 		logger.error('Failed to parse detection times blob, returning 1min', detectionTimesBlob);

--- a/src/utils/science.ts
+++ b/src/utils/science.ts
@@ -1,0 +1,94 @@
+import { getPath } from "@/store/store";
+import { SkillLevels, getHighestSkillLevel } from "./groups";
+import { ScienceAnalysisTimes, Stores } from "@/store/types";
+import { logger } from "@/logger";
+import { Duration } from "./time";
+import { ArtifactEntry, Artifact } from "@/models/artifact";
+import Bookshelf from 'bookshelf';
+
+const EVA_ID = '20263';
+
+const SampleTypes = {
+	BLOOD_SAMPLE: 'Blood sample',
+	GENE_SAMPLE: 'Gene sample',
+	MATERIAL_SAMPLE: 'Material sample',
+	OTHER_SAMPLE: 'Other sample',
+	MICROSCOPE_SAMPLE: 'Microscopic analysis',
+	AGE: 'Radiocarbon dating',
+	HISTORY_SAMPLE: 'Historical analysis',
+	XRF_SAMPLE: 'X-Ray Fluorescence analysis',
+} as const;
+
+export const addOperationResultsToArtifactEntry = async (operationResult: Bookshelf.Model<unknown>) => {
+	const operationType = operationResult.get('additional_type');
+	const catalogId = operationResult.get('catalog_id');
+	if (!catalogId) return;
+
+	const artifact = await Artifact.forge().where({ catalog_id: catalogId }).fetchWithRelated();
+	if (!artifact) return;
+
+	let entryText: string | null;
+	switch (operationType) {
+		case 'MATERIAL_SAMPLE':
+			entryText = artifact.get('test_material');
+			break;
+		case 'MICROSCOPE_SAMPLE':
+			entryText = artifact.get('test_microscope');
+			break;
+		case 'AGE':
+			entryText = artifact.get('test_age');
+			break;
+		case 'XRF_SAMPLE':
+			entryText = artifact.get('test_xrf');
+			break;
+		case 'HISTORY_SAMPLE':
+			entryText = artifact.get('test_history');
+			break;
+		default:
+			entryText = null;
+	}
+
+	// TODO: Check from artifact.entries[].entry if the operation result is already added (contains entryText)
+	// if it does, throw a specific error, and give a specific response to the user
+
+	if (entryText) {
+		entryText = `542 **${SampleTypes[operationType] ?? operationType} results:** ${entryText}`;
+	} else {
+		entryText = `542 **${SampleTypes[operationType] ?? operationType} results:** No significant findings were discovered.`;
+	}
+
+	const entry = new ArtifactEntry();
+	await entry.save({
+		artifact_id: artifact.get('id'),
+		entry: entryText,
+		person_id: EVA_ID
+	});
+	await operationResult.save({ is_complete: true }, { method: 'update', patch: true });
+	logger.success(`Added #${operationResult.get("id")} ${operationType} results to artifact ${artifact.get('name')} (${artifact.get('catalog_id')})`);
+};
+
+export const getScienceAnalysisTime = (analysisAuthor: unknown): number => {
+	const skillLevel = getHighestSkillLevel(analysisAuthor);
+	const detectionTimesBlob = getPath(['data', 'misc', Stores.ScienceAnalysisTimes]);
+	const detectionTimes = ScienceAnalysisTimes.safeParse(detectionTimesBlob);
+	if (!detectionTimes.success) {
+		logger.error('Failed to parse science analysis times blob, returning 20min', detectionTimesBlob);
+		return Duration.minutes(20);
+	}
+
+	// TODO: Get data from blob once it's available
+	const isA550PluggedIn = true;
+
+	const addedTime = isA550PluggedIn ? 0 : detectionTimes.data.analysis_times.a550_time_reduction;
+
+	switch (skillLevel) {
+		case SkillLevels.Expert:
+			return detectionTimes.data.analysis_times[SkillLevels.Expert] + addedTime;
+		case SkillLevels.Master:
+			return detectionTimes.data.analysis_times[SkillLevels.Master] + addedTime;
+		case SkillLevels.Novice:
+			return detectionTimes.data.analysis_times[SkillLevels.Novice]+ addedTime;
+		default:
+			return Duration.minutes(20);
+	}
+};


### PR DESCRIPTION
Science test results will be automatically posted to artifact entries. Delivery time is determined by the scientist's skill level and the state of A550 prop (to be implemented later).

Also adds a data blob for mapping NFC tag UIDs to artifact catalog IDs that can be used for artifact lookup via a NFC UID reader attached to a PC running datahub.