### PR TITLE
feat: send DMX signals on all EE health changes

### DIFF
--- a/db/redux/ship/index.js
+++ b/db/redux/ship/index.js
@@ -5,10 +5,10 @@ saveBlob({
 	type: 'ship',
 	id: 'jump',
 	status: 'ready_to_prep',
-	jump_at: 0,		// millisecond timestamp
-	last_jump: 0,	// millisecond timestamp
+	jump_at: 0, // millisecond timestamp
+	last_jump: 0, // millisecond timestamp
 	breaking_jump: true,
-	minor_breaking_jump: true,  // first jump is always minor-breaking
+	minor_breaking_jump: true, // first jump is always minor-breaking
 	presets: {
 		cooldown: {
 			status: 'cooldown',
@@ -22,8 +22,9 @@ saveBlob({
 		},
 		preparation: {
 			status: 'preparation',
-			note: 'Switch to \'preparation\' state ONLY from \'calculating\' state! ' +
-                'Otherwise engineering tasks are not properly initialized.',
+			note:
+				"Switch to 'preparation' state ONLY from 'calculating' state! " +
+				'Otherwise engineering tasks are not properly initialized.',
 		},
 		prep_complete: {
 			status: 'prep_complete',
@@ -90,7 +91,7 @@ saveBlob({
 			frontshieldHeat: 0,
 			impulseHeat: 0,
 			jumpdriveHeat: 0,
-			warpHeat: 0
+			warpHeat: 0,
 		},
 		health: {
 			frontshieldHealth: 1,
@@ -101,15 +102,15 @@ saveBlob({
 			reactorHealth: 1,
 			maneuverHealth: 1,
 			warpHealth: 1,
-			beamweaponsHealth: 1
-		}
+			beamweaponsHealth: 1,
+		},
 	},
 	weapons: {
 		homingCount: 12,
 		nukeCount: 4,
 		hvliCount: 20,
 		mineCount: 8,
-		empCount: 6
+		empCount: 6,
 	},
 	general: {
 		alertLevel: 'Normal',
@@ -129,4 +130,21 @@ saveBlob({
 	isEmulated: true,
 	id: 'ee_metadata',
 	type: 'ship',
+});
+
+// Limits on which normal/damaged/critical DMX health signals will be sent
+saveBlob({
+	help: 'Limits on which normal/damaged/critical/disabled DMX health signals will be sent. Values are for critical-damaged and damaged-normal limits. Disabled is always <= 0.',
+	type: 'ship',
+	id: 'dmx_limits',
+	reactor: [0.25, 0.7],
+	rearshield: [0.25, 0.7],
+	missilesystem: [0.25, 0.7],
+	maneuver: [0.25, 0.7],
+	beamweapons: [0.25, 0.7],
+	frontshield: [0.25, 0.7],
+	impulse: [0.25, 0.7],
+	hull: [0.25, 0.7],
+	lifesupport: [0.25, 0.7],
+	general: [0.25, 0.7],
 });

--- a/src/dmx.ts
+++ b/src/dmx.ts
@@ -21,10 +21,6 @@ export const CHANNELS = {
 	JumpEndBreaking: 111,
 	JumpAbort: 112,
 
-	LifeSupportNormal: 115,
-	LifeSupportLow: 116,
-	LifeSupportCritical: 117,
-
 	ShipAnnouncement: 119,
 
 	// Used in fuse box configuration
@@ -39,11 +35,61 @@ export const CHANNELS = {
 	LoungeFuseBroken: 128,
 	LoungeFuseFixed: 129,
 
-	ReactorNormal: 140,
-	ReactorCritical: 141,
-	ReactorOff: 142,
-	GeneralStatusNormal: 143,
-	GeneralStatusBroken: 144,
+	// Health statuses
+	FrontShieldNormal: 200,
+	FrontShieldDamaged: 201,
+	FrontShieldCritical: 202,
+	FrontShieldDisabled: 203,
+	FrontShieldValue: 204,
+	RearShieldNormal: 205,
+	RearShieldDamaged: 206,
+	RearShieldCritical: 207,
+	RearShieldDisabled: 208,
+	RearShieldValue: 209,
+	ImpulseNormal: 210,
+	ImpulseDamaged: 211,
+	ImpulseCritical: 212,
+	ImpulseDisabled: 213,
+	ImpulseValue: 214,
+	MissileSystemNormal: 215,
+	MissileSystemDamaged: 216,
+	MissileSystemCritical: 217,
+	MissileSystemDisabled: 218,
+	MissileSystemValue: 219,
+	ReactorNormal: 220,
+	ReactorDamaged: 221,
+	ReactorCritical: 222,
+	ReactorDisabled: 223,
+	ReactorValue: 224,
+	ManeuverNormal: 225,
+	ManeuverDamaged: 226,
+	ManeuverCritical: 227,
+	ManeuverDisabled: 228,
+	ManeuverValue: 229,
+	BeamWeaponsNormal: 230,
+	BeamWeaponsDamaged: 231,
+	BeamWeaponsCritical: 232,
+	BeamWeaponsDisabled: 233,
+	BeamWeaponsValue: 234,
+	HullNormal: 235,
+	HullDamaged: 236,
+	HullCritical: 237,
+	HullDisabled: 238,
+	HullValue: 239,
+
+	LifeSupportNormal: 240,
+	LifeSupportDamaged: 241,
+	LifeSupportCritical: 242,
+	// Life support does not use 'disabled' signal
+	// LifeSupportDisabled: 243,
+	LifeSupportValue: 244,
+
+	GeneralStatusNormal: 245,
+	GeneralStatusDamaged: 246,
+	GeneralStatusCritical: 247,
+	GeneralStatusDisabled: 248,
+	GeneralStatusValue: 249,
+
 	DriftingValueOutOfRange: 145,
 	DriftingValueInRange: 146,
 
@@ -106,7 +152,7 @@ function init(): Dmx {
 	} else {
 		return {
 			update: (universe: string, value: Record<number, number>) => {
-				logger.debug(`DMX update on universe ${universe}: ${JSON.stringify(value)}`);
+				logger.debug(`Mock DMX update on universe ${universe}: ${JSON.stringify(value)}`);
 			},
 		};
 	}
@@ -133,4 +179,20 @@ export function fireEvent(channel: Channel, value = 255) {
 
 	// Send TP-link power socker on/off. Intentionally not awaited.
 	processDmxSignal(findChannelName(channel));
+}
+
+export function mapDmxValue(value: number, inMin: number, inMax: number): number {
+	const outMin = 0;
+	const outMax = 255;
+	const outValue = Math.round(outMin + ((outMax - outMin) * (value - inMin)) / (inMax - inMin));
+	return Math.min(Math.max(outValue, outMin), outMax);
+}
+
+export function setDmxValue(channel: Channel, value: number) {
+	if (!isNumber(channel) || !isNumber(value) || channel < 0 || channel > 255 || value < 0 || value > 255) {
+		logger.error(`Attempted DMX setDmxValue with invalid channel=${channel} or value=${value}`);
+		return;
+	}
+	logger.debug(`Setting DMX channel ${channel} (${findChannelName(channel)}) value ${value}`);
+	dmx.update(UNIVERSE_NAME, { [channel]: value });
 }

--- a/src/rules/ship/eeHealthDmx.js
+++ b/src/rules/ship/eeHealthDmx.js
@@ -1,88 +1,153 @@
 import { interval } from '../helpers';
 import store, { watch } from '../../store/store';
-import { fireEvent, CHANNELS } from '../../dmx';
-
+import { fireEvent, CHANNELS, mapDmxValue, setDmxValue } from '../../dmx';
+import { logger } from '@/logger';
 
 const GENERAL_HEALTH_TYPES = [
 	'reactor',
 	'impulse',
 	'maneuver',
-	'hull',  // special case
+	'hull', // special case
 	'lifesupport', // special case
 ];
+
+const ALL_REPORTED_HEALTH_TYPES = {
+	// Base EE health values are in range -1 .. 1
+	// jumpdrive + warp are unused and thus missing
+	frontshield: {
+		disabled: CHANNELS.FrontShieldDisabled,
+		critical: CHANNELS.FrontShieldCritical,
+		damaged: CHANNELS.FrontShieldDamaged,
+		normal: CHANNELS.FrontShieldNormal,
+		value: CHANNELS.FrontShieldValue,
+	},
+	rearshield: {
+		disabled: CHANNELS.RearShieldDisabled,
+		critical: CHANNELS.RearShieldCritical,
+		damaged: CHANNELS.RearShieldDamaged,
+		normal: CHANNELS.RearShieldNormal,
+		value: CHANNELS.RearShieldValue,
+	},
+	impulse: {
+		disabled: CHANNELS.ImpulseDisabled,
+		critical: CHANNELS.ImpulseCritical,
+		damaged: CHANNELS.ImpulseDamaged,
+		normal: CHANNELS.ImpulseNormal,
+		value: CHANNELS.ImpulseValue,
+	},
+	missilesystem: {
+		disabled: CHANNELS.MissileSystemDisabled,
+		critical: CHANNELS.MissileSystemCritical,
+		damaged: CHANNELS.MissileSystemDamaged,
+		normal: CHANNELS.MissileSystemNormal,
+		value: CHANNELS.MissileSystemValue,
+	},
+	reactor: {
+		disabled: CHANNELS.ReactorDisabled,
+		critical: CHANNELS.ReactorCritical,
+		damaged: CHANNELS.ReactorDamaged,
+		normal: CHANNELS.ReactorNormal,
+		value: CHANNELS.ReactorValue,
+	},
+	maneuver: {
+		disabled: CHANNELS.ManeuverDisabled,
+		critical: CHANNELS.ManeuverCritical,
+		damaged: CHANNELS.ManeuverDamaged,
+		normal: CHANNELS.ManeuverNormal,
+		value: CHANNELS.ManeuverValue,
+	},
+	beamweapons: {
+		disabled: CHANNELS.BeamWeaponsDisabled,
+		critical: CHANNELS.BeamWeaponsCritical,
+		damaged: CHANNELS.BeamWeaponsDamaged,
+		normal: CHANNELS.BeamWeaponsNormal,
+		value: CHANNELS.BeamWeaponsValue,
+	},
+	// Hull is between 0 .. 1
+	hull: {
+		disabled: CHANNELS.HullDisabled,
+		critical: CHANNELS.HullCritical,
+		damaged: CHANNELS.HullDamaged,
+		normal: CHANNELS.HullNormal,
+		value: CHANNELS.HullValue,
+		min: 0,
+		max: 1,
+	},
+	// 'general' is average of a few main types
+	general: {
+		disabled: CHANNELS.GeneralStatusDisabled,
+		critical: CHANNELS.GeneralStatusCritical,
+		damaged: CHANNELS.GeneralStatusDamaged,
+		normal: CHANNELS.GeneralStatusNormal,
+		value: CHANNELS.GeneralStatusValue,
+	},
+	// Life support is reported separatedly in lifesupport.js because it also sends ship log events
+};
 
 function getEEHealth(ee, type) {
 	if (type === 'hull') {
 		return ee.general.shipHullPercent;
 	} else if (type === 'lifesupport') {
 		return store.getState().data.ship.lifesupport.health;
+	} else if (type === 'general') {
+		const average =
+			GENERAL_HEALTH_TYPES.map(type => getEEHealth(ee, type)).reduce((a, b) => a + b) / GENERAL_HEALTH_TYPES.length;
+		return average;
 	} else {
 		const typeHealth = `${type}Health`;
 		return ee.systems.health[typeHealth];
 	}
 }
 
-const NORMAL = 1;
-const CRITICAL = 2;
-const OFF = 3;
-
-let reactorHealthStatus = NORMAL;
-function updateReactorHealth() {
-	const status = getReactorStatus();
-	if (reactorHealthStatus !== status) {
-		switch (status) {
-			case NORMAL:
-				fireEvent(CHANNELS.ReactorNormal);
-				break;
-			case CRITICAL:
-				fireEvent(CHANNELS.ReactorCritical);
-				break;
-			case OFF:
-				fireEvent(CHANNELS.ReactorOff);
-				break;
-		}
-		reactorHealthStatus = status;
+/*
+ * dmx_limits definition:
+ * {
+ *    reactor: [0.3, 0.7],  // critical, damaged limits
+ *    ...
+ * }
+ */
+function getHealthStatus(type, value) {
+	const limits = store.getState().data.ship.dmx_limits;
+	if (!limits || !limits[type]) {
+		logger.error(`dmx_limits blob not found or no entry for health type ${type}`);
+		return 'normal';
 	}
-}
-
-function getReactorStatus() {
-	const ee = store.getState().data.ship.ee;
-	const health = getEEHealth(ee, 'reactor');
-	if (health <= 0) {
-		return OFF;
-	} else if (health <= 0.45) {
-		return CRITICAL;
+	const criticalLimit = limits[type][0];
+	const damagedLimit = limits[type][1];
+	if (value <= 0) {
+		return 'disabled';
+	} else if (value <= criticalLimit) {
+		return 'critical';
+	} else if (value <= damagedLimit) {
+		return 'damaged';
 	} else {
-		return NORMAL;
+		return 'normal';
 	}
 }
 
+const previousHealthStatus = {};
+const previousHealthValue = {};
 
-
-// General health status DMX signals
-
-let generalStatusBroken = false;
-function updateGeneralHealth() {
-	// condition: average of (hull, reactor, impulse, life support, maneuver) < 40%
+function updateHealthValues() {
 	const ee = store.getState().data.ship.ee;
-	const average = GENERAL_HEALTH_TYPES.map(type => getEEHealth(ee, type)).reduce((a, b) => a+b) / GENERAL_HEALTH_TYPES.length;
-	if (average < 0.4) {
-		if (!generalStatusBroken) {
-			fireEvent(CHANNELS.GeneralStatusBroken);
-			generalStatusBroken = true;
+	for (const [type, settings] of Object.entries(ALL_REPORTED_HEALTH_TYPES)) {
+		const value = getEEHealth(ee, type);
+		const status = getHealthStatus(type, value);
+		const dmxValue = mapDmxValue(value, settings.min ?? -1, settings.max ?? 1);
+		if (status !== previousHealthStatus[type]) {
+			const channel = settings[status];
+			if (channel) {
+				fireEvent(channel);
+			}
+			previousHealthStatus[type] = status;
 		}
-	} else {
-		if (generalStatusBroken) {
-			fireEvent(CHANNELS.GeneralStatusNormal);
-			generalStatusBroken = false;
+		if (value !== previousHealthValue[type]) {
+			setDmxValue(settings.value, dmxValue);
+			previousHealthValue[type] = value;
 		}
 	}
 }
 
-
-watch(['data', 'ship', 'ee'], updateGeneralHealth);
-watch(['data', 'ship', 'lifesupport'], updateGeneralHealth);
-interval(updateGeneralHealth, 10000);
-
-watch(['data', 'ship', 'ee'], updateReactorHealth);
-interval(updateReactorHealth, 10000);
+watch(['data', 'ship', 'ee'], updateHealthValues);
+watch(['data', 'ship', 'lifesupport'], updateHealthValues);
+interval(updateHealthValues, 30000); // in case something is missed


### PR DESCRIPTION
- Sends four-level signals on all healths (normal, damaged, critical, disabled)
- Sends the actual health value as a DMX value
- Limits of normal-damaged and damaged-critical are read from blob