### PR TITLE
Change spectral calibration task to jump crystal insertion task

### DIFF
--- a/db/redux/box/jumpdrive.js
+++ b/db/redux/box/jumpdrive.js
@@ -1,20 +1,37 @@
 const blobs = [];
 
 blobs.push({
-	id: 'jump_drive_spectral_calibration',
-	type: 'box',
+	id: 'jump_drive_insert_jump_crystal',
+	type: 'game',
+	task: 'jump_drive_insert_jump_crystal',
+	game_config: 'manual',
 	status: 'initial',
-	task: 'jump_drive_spectral_calibration',
+	config: {
+		title: 'Insert Jump Drive Jump Crystals',
+		pages: [
+			"<p>Perform the manual task according to instructions.</p><p>Insert the jump crystals into the designated ports to enable the ship's jump drive. Refer to ESS Odysseus Operations Handbook page 2.6-56 for instructions.</p>",
+			"<p>Insert Crystal into Port. Ensure each crystal is securely locked into place.</p>",
+			"<p>Proceed to the calibration phase once the crystals are inserted.</p>"
+		],
+		buttons: [
+			'Instructions',
+			'Next',
+			'Calibrate'
+		]
+	}
 });
 
 blobs.push({
-	id: 'jump_drive_spectral_calibration',
+	id: 'jump_drive_insert_jump_crystal',
 	type: 'task',
+	game: 'jump_drive_insert_jump_crystal',
+	singleUse: false,
+	used: false,
 	status: 'initial',
-	title: 'Jump drive spectral calibration',
-	description: 'Perform jump drive spectral calibration (separate instructions).',
-	calibrationTime: 2.5*60,
 	calibrationCount: 1,
+	calibrationTime: 2.5*60,
+	title: 'Insert jump crystal to Jump drive',
+	description: 'Insert jump crystal to Jump drive (separate instructions on ESS Odysseus Operations Handbook page 2.6-56).',
 	location: 'Upper deck, engineering',
 	map: 'upper-5.png',
 	mapX: 400,

--- a/src/rules/ship/jump.js
+++ b/src/rules/ship/jump.js
@@ -125,9 +125,9 @@ function getReadableJumpTarget(coordinates) {
 		: gridName;
 }
 
-function isJumpSpectralCalibrationDone() {
+function isJumpCrystalDone() {
 	const tasks = store.getState().data.task;
-	return tasks.jump_drive_spectral_calibration.status === 'fixed';
+	return tasks.jump_drive_insert_jump_crystal.status === 'fixed';
 }
 
 function isJumpReactorDone() {
@@ -136,19 +136,19 @@ function isJumpReactorDone() {
 }
 
 function setupJumpDriveTasks() {
-	breakSpectralCalibration();
+	breakJumpCrystalGame();
 	breakJumpReactor();
 }
 
-function breakSpectralCalibration() {
-	const boxes = store.getState().data.box;
-	if (boxes.jump_drive_spectral_calibration) {
+function breakJumpCrystalGame() {
+	const games = store.getState().data.game;
+	if (games.jump_drive_insert_jump_crystal) {
 		saveBlob({
-			...boxes.jump_drive_spectral_calibration,
+			...games.jump_drive_insert_jump_crystal,
 			status: 'broken',
 		});
 	} else {
-		logger.error("No box with id 'jump_drive_spectral_calibration'");
+		logger.error("No box with id 'jump_drive_insert_jump_crystal'");
 	}
 }
 
@@ -402,7 +402,7 @@ function handleStatic(jump) {
 		case 'preparation':
 			// Avoid race condition when transitioning to 'preparation' and tasks are not yet set up
 			if (Date.now() > jump.updated_at + 500) {
-				if (isJumpSpectralCalibrationDone() && isJumpReactorDone()) {
+				if (isJumpCrystalDone() && isJumpReactorDone()) {
 					saveBlob({
 						...jump,
 						status: 'prep_complete',


### PR DESCRIPTION
Old Spectral Calibration task cannot be reused so the task is now changed to a manual engineering task to insert jump crystal to the jump drive. The task can be performed using HANSCA by the players. No need GMs to mark it done.
Might need to update instructions when the manual task is done during the building. 

Picture from blob storage from Admin UI.
![image](https://github.com/OdysseusLarp/odysseus-backend/assets/36162517/60797abe-6ddb-4bd2-a30e-1acbe42bf08d)