### PR TITLE
feat: allow emergency overrides for big battery locations

### DIFF
--- a/db/redux/box/bigbattery.js
+++ b/db/redux/box/bigbattery.js
@@ -12,9 +12,24 @@ blobs.push({
 	// Whether box is currently actively used (set by backend), affects tube glowing
 	active: false,
 	// Brightness of Neopixel LEDs 1-255 (configuration)
-	brightness: 20,
+	brightness: 10,
 	// In what time is the battery depleted from 100% to 0%, minutes (configuration)
 	depletion_time_mins: 3 * 60 + 15,
+	// Set to integer values of locations where device is always assumed to be connected + charged.
+	// For disaster situations where the real device no longer works.
+	emergency_assumed_at_positions: [],
+
+	presets: {
+		set_full_capacity: {
+			capacity_percent: 100,
+		},
+		assume_battery_everywhere: {
+			emergency_assumed_at_positions: [1, 2, 3, 4, 5, 6, 7, 8, 9],
+		},
+		assume_battery_nowhere: {
+			emergency_assumed_at_positions: [],
+		},
+	},
 });
 
 export default blobs;

--- a/src/rules/boxes/bigbattery.ts
+++ b/src/rules/boxes/bigbattery.ts
@@ -29,6 +29,7 @@ function updateActiveStatus() {
 		return;
 	}
 
+	// NOTE: This intentionally does not use isBatteryConnected since emergency overrides are undesired here
 	let active = false;
 	switch (box.connected_position) {
 		case BigBatteryLocation.ENGINEERING:

--- a/src/utils/bigbattery-helpers.ts
+++ b/src/utils/bigbattery-helpers.ts
@@ -22,18 +22,36 @@ export interface BigBattery {
 	brightness: number;
 	// In what time is the battery depleted from 100% to 0%, minutes (configuration)
 	depletion_time_mins: number;
+	// Emergency assumed at positions (configuration)
+	emergency_assumed_at_positions: BigBatteryLocation[];
 }
 
 /**
  * Check whether big battery is connected to the specified location and has charge remaining.
  */
-export function isBatteryConnectedAndCharged(battery: BigBattery | undefined, location: BigBatteryLocation) {
+export function isBatteryConnectedAndCharged(
+	battery: BigBattery | undefined,
+	location: BigBatteryLocation,
+	allow_emergency_override = true
+) {
+	if (allow_emergency_override && (battery?.emergency_assumed_at_positions ?? []).includes(location)) {
+		// Emergency override allows to assume battery is always connected here
+		return true;
+	}
 	return battery?.connected_position === location && battery?.capacity_percent > 0;
 }
 
 /**
  * Check whether big battery is connected to the specified location (regardless whether charged).
  */
-export function isBatteryConnected(battery: BigBattery | undefined, location: BigBatteryLocation) {
+export function isBatteryConnected(
+	battery: BigBattery | undefined,
+	location: BigBatteryLocation,
+	allow_emergency_override = true
+) {
+	if (allow_emergency_override && (battery?.emergency_assumed_at_positions ?? []).includes(location)) {
+		// Emergency override allows to assume battery is always connected here
+		return true;
+	}
 	return battery?.connected_position === location;
 }


### PR DESCRIPTION
In case the big battery device fails, set emergency_assumed_at_positions to appropriate locations (all or even single one if only one location is causing problems eg due to wifi).
It will assume the big battery to always be connected at those locations.