### PR TITLE
Kick box

### DIFF
--- a/db/redux/box/fuseboxes.js
+++ b/db/redux/box/fuseboxes.js
@@ -3,56 +3,56 @@ const boxes = [
 		type: 'box',
 		id: 'fusebox_medbay',
 		config: {
-			blowing: [4, 15, 18, 22, 24,  9, 11, 7],
-			measure: [14, 17, 27, 23, 10, 25,  8, 5],
+			blowing: [4, 15, 18, 22, 24, 9, 11, 7],
+			measure: [14, 17, 27, 23, 10, 25, 8, 5],
 		},
-		dmxFuse: 5,  // Which fuse index triggers the following DMX events (optional)
-		dmxFixed: 'MedbayFuseFixed',
-		dmxBroken: 'MedbayFuseBroken',
+		dmxFuse: 5, // Which fuse index triggers the following DMX events (optional)
+		dmxFuseFixed: 'MedbayFuseFixed',
+		dmxFuseBroken: 'MedbayFuseBroken',
 	},
 	{
 		type: 'box',
 		id: 'fusebox_engineering',
 		config: {
-			blowing: [4, 15, 18, 22, 24,  9, 11, 7],
-			measure: [14, 17, 27, 23, 10, 25,  8, 5],
+			blowing: [4, 15, 18, 22, 24, 9, 11, 7],
+			measure: [14, 17, 27, 23, 10, 25, 8, 5],
 		},
 		dmxFuse: 7,
-		dmxFixed: 'EngineeringFuseFixed',
-		dmxBroken: 'EngineeringFuseBroken',
+		dmxFuseFixed: 'EngineeringFuseFixed',
+		dmxFuseBroken: 'EngineeringFuseBroken',
 	},
 	{
 		type: 'box',
 		id: 'fusebox_bridge',
 		config: {
-			blowing: [4, 15, 18, 22, 24,  9, 11, 7,  6, 13, 16, 20],
-			measure: [14, 17, 27, 23, 10, 25,  8, 5, 12, 19, 26, 21],
+			blowing: [4, 15, 18, 22, 24, 9, 11, 7, 6, 13, 16, 20],
+			measure: [14, 17, 27, 23, 10, 25, 8, 5, 12, 19, 26, 21],
 		},
 		dmxFuse: 4,
-		dmxFixed: 'BridgeFuseFixed',
-		dmxBroken: 'BridgeFuseBroken',
+		dmxFuseFixed: 'BridgeFuseFixed',
+		dmxFuseBroken: 'BridgeFuseBroken',
 	},
 	{
 		type: 'box',
 		id: 'fusebox_science',
 		config: {
-			blowing: [4, 15, 18, 22, 24,  9, 11, 7],
-			measure: [14, 17, 27, 23, 10, 25,  8, 5],
+			blowing: [4, 15, 18, 22, 24, 9, 11, 7],
+			measure: [14, 17, 27, 23, 10, 25, 8, 5],
 		},
 		dmxFuse: 1,
-		dmxFixed: 'ScienceFuseFixed',
-		dmxBroken: 'ScienceFuseBroken',
+		dmxFuseFixed: 'ScienceFuseFixed',
+		dmxFuseBroken: 'ScienceFuseBroken',
 	},
 	{
 		type: 'box',
 		id: 'fusebox_lounge',
 		config: {
-			blowing: [4, 15, 18, 22, 24,  9, 11, 7],
-			measure: [14, 17, 27, 23, 10, 25,  8, 5],
+			blowing: [4, 15, 18, 22, 24, 9, 11, 7],
+			measure: [14, 17, 27, 23, 10, 25, 8, 5],
 		},
 		dmxFuse: 6,
-		dmxFixed: 'LoungeFuseFixed',
-		dmxBroken: 'LoungeFuseBroken',
+		dmxFuseFixed: 'LoungeFuseFixed',
+		dmxFuseBroken: 'LoungeFuseBroken',
 	},
 ];
 
@@ -61,7 +61,8 @@ const tasks = [
 		type: 'task',
 		id: 'fusebox_medbay',
 		title: 'Life support fuse failure (medbay)',
-		description: 'Life support fuses have blown in medbay.\n\nReplace broken fuses as instructed in Ship knowledge database code SQ-3 or operation manual page 2.2-38.',
+		description:
+			'Life support fuses have blown in medbay.\n\nReplace broken fuses as instructed in Ship knowledge database code SQ-3 or operation manual page 2.2-38.',
 		location: 'Upper deck, medbay',
 		map: 'upper-6.png',
 		mapX: 80,
@@ -71,7 +72,8 @@ const tasks = [
 		type: 'task',
 		id: 'fusebox_engineering',
 		title: 'Life support fuse failure (engineering)',
-		description: 'Life support fuses have blown in engineering.\n\nReplace broken fuses as instructed in Ship knowledge database code SQ-3 or operation manual page 2.2-38.',
+		description:
+			'Life support fuses have blown in engineering.\n\nReplace broken fuses as instructed in Ship knowledge database code SQ-3 or operation manual page 2.2-38.',
 		location: 'Upper deck, engineering storage',
 		map: 'upper-4.png',
 		mapX: 230,
@@ -81,7 +83,8 @@ const tasks = [
 		type: 'task',
 		id: 'fusebox_bridge',
 		title: 'Life support fuse failure (bridge)',
-		description: 'Life support fuses have blown in bridge.\n\nReplace broken fuses as instructed in Ship knowledge database code SQ-3 or operation manual page 2.2-38.',
+		description:
+			'Life support fuses have blown in bridge.\n\nReplace broken fuses as instructed in Ship knowledge database code SQ-3 or operation manual page 2.2-38.',
 		location: 'Upper deck, bridge',
 		map: 'upper-2.png',
 		mapX: 140,
@@ -91,7 +94,8 @@ const tasks = [
 		type: 'task',
 		id: 'fusebox_science',
 		title: 'Life support fuse failure (science lab)',
-		description: 'Life support fuses have blown in science lab.\n\nReplace broken fuses as instructed in Ship knowledge database code SQ-3 or operation manual page 2.2-38.',
+		description:
+			'Life support fuses have blown in science lab.\n\nReplace broken fuses as instructed in Ship knowledge database code SQ-3 or operation manual page 2.2-38.',
 		location: 'Lower deck, science lab',
 		map: 'lower-13.png',
 		mapX: 350,
@@ -101,8 +105,9 @@ const tasks = [
 		type: 'task',
 		id: 'fusebox_lounge',
 		title: 'Life support fuse failure (celestial lounge)',
-		description: 'Life support fuses have blown in celestial lounge.\n\nReplace broken fuses as instructed in Ship knowledge database code SQ-3 or operation manual page 2.2-38.',
-		location: 'Upper deck, officer\'s lounge',
+		description:
+			'Life support fuses have blown in celestial lounge.\n\nReplace broken fuses as instructed in Ship knowledge database code SQ-3 or operation manual page 2.2-38.',
+		location: "Upper deck, officer's lounge",
 		map: 'upper-9.png',
 		mapX: 250,
 		mapY: 220,
@@ -115,10 +120,10 @@ boxes.forEach(e => {
 	e.fuses = e.config.blowing.map(() => 1);
 	e.presets = {
 		blow_one: {
-			blow: [0]
+			blow: [0],
 		},
 		blow_all: {
-			blow: e.config.blowing.map((e, index) => index)
+			blow: e.config.blowing.map((e, index) => index),
 		},
 	};
 });
@@ -129,6 +134,5 @@ tasks.forEach(e => {
 	e.calibrationCount = 0;
 	e.important = false;
 });
-
 
 export default [...boxes, ...tasks];

--- a/db/redux/box/index.ts
+++ b/db/redux/box/index.ts
@@ -6,6 +6,7 @@ import driftingValueBlobs from './driftingValue';
 import buttonboard from './buttonboard';
 import reactorWiring from './reactorWiring';
 import bigbattery from './bigbattery';
+import kick from './kick';
 
 const blobs = [
 	...airlock,
@@ -15,5 +16,6 @@ const blobs = [
 	...buttonboard,
 	...reactorWiring,
 	...bigbattery,
+	...kick,
 ];
 blobs.forEach(saveBlob);

--- a/db/redux/box/kick.js
+++ b/db/redux/box/kick.js
@@ -1,0 +1,46 @@
+const blobs = [];
+
+blobs.push({
+	type: 'box',
+	id: 'thermic_fusion_regulator',
+	task: 'thermic_fusion_regulator',
+	status: 'initial',
+	config: {
+		pin: 14,
+	},
+});
+
+blobs.push({
+	type: 'task',
+	id: 'thermic_fusion_regulator',
+	box: 'thermic_fusion_regulator',
+	status: 'initial',
+	failure_probability_per_minute: 0.01, // On avg every 70 minutes
+	battery_charge_level_when_broken: 65,
+	title: 'Thermic Fusion Conduit blockage',
+	description:
+		'The Thermic Fusion Conduits have experienced a cryo-static blockage, resulting in an inability to expel waste heat efficiently. This blockage may cause the Thermic Fusion Regulators to overheat and malfunction.\n\nRepairs require docking at a Level 3 or higher spaceport for Fusion Conduit purging and recalibration.',
+	location: 'External hull, Thermic Fusion Conduit',
+	map: 'deck3',
+	mapX: 415,
+	mapY: 1155,
+	mapPosX: 100,
+	mapPosY: 1000,
+	calibrationTime: 0,
+	calibrationCount: 0,
+	dmxBroken: 'ThermicFusionRegulatorBroken',
+	dmxFixed: 'ThermicFusionRegulatorFixed',
+	presets: {
+		break_on_avg_30min: {
+			failure_probability_per_minute: 0.023,
+		},
+		break_on_avg_70min: {
+			failure_probability_per_minute: 0.01,
+		},
+		break_on_avg_120min: {
+			failure_probability_per_minute: 0.006,
+		},
+	},
+});
+
+export default blobs;

--- a/db/redux/box/kick.js
+++ b/db/redux/box/kick.js
@@ -5,6 +5,7 @@ blobs.push({
 	id: 'thermic_fusion_regulator',
 	task: 'thermic_fusion_regulator',
 	status: 'initial',
+	kick_success_probability: 0.6,
 	config: {
 		pin: 14,
 	},

--- a/src/dmx.ts
+++ b/src/dmx.ts
@@ -151,10 +151,15 @@ export const CHANNELS = {
 
 	// Alien artifact activation
 	// 301-303 reserved for artifacts 1-3
+	__ALIEN_ARTIFACTS__: 0,
 	JumpDriveCoolingArtifactActivated: 304,
 	CalibrationSlotArtifactActivated: 305,
 	ScanRangeExtenderArtifactActivated: 306,
 	CalibrationSpeedupArtifactActivated: 307,
+
+	__TASKS__: 0,
+	ThermicFusionRegulatorBroken: 320,
+	ThermicFusionRegulatorFixed: 321,
 } as const;
 
 type Channel = (typeof CHANNELS)[keyof typeof CHANNELS];

--- a/src/rules/boxes/fuseboxes.js
+++ b/src/rules/boxes/fuseboxes.js
@@ -11,22 +11,21 @@ watch(['data', 'box'], (boxes, previousBoxes, state) => {
 		const previous = previousBoxes[id];
 		if (previous && box.fuses && isNumber(box.dmxFuse) && box.fuses[box.dmxFuse] !== previous.fuses[box.dmxFuse]) {
 			if (box.fuses[box.dmxFuse]) {
-				if (CHANNELS[box.dmxFixed]) {
-					fireEvent(CHANNELS[box.dmxFixed]);
+				if (CHANNELS[box.dmxFuseFixed]) {
+					fireEvent(CHANNELS[box.dmxFuseFixed]);
 				} else {
-					logger.error(`Fuse box ${id} contained invalid DMX channel dmxFixed=${box.dmxFixed}`);
+					logger.error(`Fuse box ${id} contained invalid DMX channel dmxFuseFixed=${box.dmxFuseFixed}`);
 				}
 			} else {
-				if (CHANNELS[box.dmxBroken]) {
-					fireEvent(CHANNELS[box.dmxBroken]);
+				if (CHANNELS[box.dmxFuseBroken]) {
+					fireEvent(CHANNELS[box.dmxFuseBroken]);
 				} else {
-					logger.error(`Fuse box ${id} contained invalid DMX channel dmxBroken=${box.dmxBroken}`);
+					logger.error(`Fuse box ${id} contained invalid DMX channel dmxFuseBroken=${box.dmxFuseBroken}`);
 				}
 			}
 		}
 	}
 });
-
 
 // Cause life support tasks to fail if fuse blowing has failed
 watch(['data', 'box'], (boxes, previousBoxes, state) => {
@@ -35,9 +34,9 @@ watch(['data', 'box'], (boxes, previousBoxes, state) => {
 		const previous = previousBoxes[id];
 		if (previous && box.fuses && box.failed && !isEqual(box.failed, previous.failed)) {
 			const count = box.failed.length;
-			const breakCount = Math.ceil(count/3);
+			const breakCount = Math.ceil(count / 3);
 			logger.info(`${count} fuses failed to blow in ${box.id}, breaking ${breakCount} life support tasks`);
-			for (let i=0; i<breakCount; i++) {
+			for (let i = 0; i < breakCount; i++) {
 				breakTask();
 			}
 		}
@@ -62,4 +61,3 @@ function breakTask() {
 		status: 'broken',
 	});
 }
-

--- a/src/rules/boxes/kick.ts
+++ b/src/rules/boxes/kick.ts
@@ -1,0 +1,18 @@
+import store from '@/store/store';
+import { STATUS_NUMBERS } from '../ship/jumpstate';
+import { breakTask } from '../breakTask';
+import { logger } from '@/logger';
+
+function breakWithProbability() {
+	const task = store.getState().data.task.thermic_fusion_regulator;
+	const p = task.failure_probability_per_minute;
+	const occurred = Math.random() < p;
+	const jumpstate = store.getState().data.ship.jumpstate;
+	// Do not break task in ready, jump_initiated or jumping states
+	if (jumpstate.statusno < STATUS_NUMBERS.ready && occurred && task.status !== 'broken') {
+		logger.info('Randomly breaking task thermic_fusion_regulator');
+		breakTask(task);
+	}
+}
+
+setInterval(breakWithProbability, 60000);

--- a/src/rules/ship/jump.js
+++ b/src/rules/ship/jump.js
@@ -155,10 +155,12 @@ function breakJumpCoolingSystem() {
 
 function chargeBigBatteryIfConnected() {
 	const box = store.getState().data.box.bigbattery;
+	const regulator_task = store.getState().data.task.thermic_fusion_regulator;
+	const charge_level = regulator_task.status === 'broken' ? regulator_task.battery_charge_level_when_broken : 100;
 	if (isBatteryConnected(box, BigBatteryLocation.ENGINEERING)) {
 		saveBlob({
 			...box,
-			capacity_percent: 100,
+			capacity_percent: charge_level,
 		});
 	}
 }


### PR DESCRIPTION
Kick box support.  Randomly causes failure every ~70mins.  Does not break if jump drive is in ready / jump_initialised / jumping state.  If task is broken when exiting jump, big battery is charged to only 65% capacity.

Also fix: change parameter for fuse failure DMX signal

Previously fuse boxes used dmxFixed / dmxBroken which
were taken into more general use. Outcome would
have been that special fuse would be considered broken
if any fuse in the box was broken. Now changed the
config name to avoid a clash.