### PR TITLE
Fix airlock related DMX mappings (and add new "Anthem" manual event)

### DIFF
--- a/src/dmx.ts
+++ b/src/dmx.ts
@@ -125,16 +125,13 @@ export const CHANNELS = {
 
 	// Airlock events
 	__AIRLOCK_EVENTS__: 0,
-	MainAirlockDoorClose: 190,
-	MainAirlockDoorOpen: 191,
-	MainAirlockDoorMalfunction: 192,
+	MainAirlockDoorLock: 190,
+	MainAirlockDoorUnlock: 191,
 	MainAirlockPressurize: 193,
-	MainAirlockDepressurize: 194,
+	MainAirlockDepressurizeSlow: 194,
+	MainAirlockDepressurizeFast: 289,
 	HangarBayDoorLock: 195,
 	HangarBayDoorUnlock: 196,
-	HangarBayDoorMalfunction: 197,
-	HangarBayPressurize: 198,
-	HangarBayDepressurize: 199,
 
 	__SHIP_NOTIFICATIONS__: 0,
 	LoraBeaconSignalDecrypted: 250,

--- a/src/dmx.ts
+++ b/src/dmx.ts
@@ -167,6 +167,7 @@ export const CHANNELS = {
 	ThermicFusionRegulatorAnnouncement: 334,
 	StarcallerLaunched: 335,
 	StarcallerEmp: 336,
+	Anthem: 337,
 } as const;
 
 type Channel = (typeof CHANNELS)[keyof typeof CHANNELS];


### PR DESCRIPTION
I forgot to update these mappings when I changed some of the DMX event names in https://github.com/OdysseusLarp/odysseus-backend/pull/51, causing some airlock DMX events to break. Let's fix them. I will also update the Sound Design Master file accordingly.

I also snuck in the addition of `Anthem: 337` per request by Pentti. It is already included in the master file.