### PR TITLE
Fine tune airlock default transition times to match 2024 sounds better

### DIFF
--- a/src/rules/boxes/airlock.js
+++ b/src/rules/boxes/airlock.js
@@ -10,11 +10,11 @@ const DEFAULT_CONFIG = {
 };
 
 const DEFAULT_TRANSITION_TIMES = {
-	open: 6000,
+	open: 6500,
 	close: 5000,
-	pressurize: 60000,
-	depressurize: 600000,
-	evacuate: 30000,
+	pressurize: 73000,
+	depressurize: 601000,
+	evacuate: 42000,
 };
 
 function now() {


### PR DESCRIPTION
These have already been fine tuned in the config data blobs for run 1, but might as well update the default values to match. 