### PR TITLE
Use Oxanium font for survivor count header too

### DIFF
--- a/db/seeds/05-infoboard.js
+++ b/db/seeds/05-infoboard.js
@@ -4,7 +4,7 @@ const infos = [
 		enabled: true,
 		title: 'Public announcement',
 		identifier: "survivors-count",
-		body: '<div style="width: 100%; height: 100%; display: flex; flex-direction: column; align-items: center; justify-content: center; font-size: 5vw;">Total souls alive <p style="font-size: 7vw; font-family: Oxanium;"><span class="survivors">%%survivor_count%%</span></p></div>',
+		body: '<div style="width: 100%; height: 100%; display: flex; flex-direction: column; align-items: center; justify-content: center; font-size: 5vw; font-family: Oxanium">Total souls alive <p style="font-size: 7vw;"><span class="survivors">%%survivor_count%%</span></p></div>',
 	},
 ];
 


### PR DESCRIPTION

> [!WARNING]
> NB: I have no idea how to test this, so someone might want to do visual validation before shipping this off to Arati.

---

Should fix the arialness found in this screenshot from YLE's news about Odysseus.

<img src="https://github.com/OdysseusLarp/odysseus-backend/assets/58669/0a36bdef-2932-409a-a038-a1fe5faa1607" width="200" />
