### PR TITLE
Add cooldown to EE health DMX events

### DIFF
--- a/db/redux/ship/index.js
+++ b/db/redux/ship/index.js
@@ -165,4 +165,5 @@ saveBlob({
 	hull: [0.25, 0.7],
 	lifesupport: [0.25, 0.7],
 	general: [0.25, 0.7],
+	cooldown_seconds: 60,
 });


### PR DESCRIPTION
Prevent "shields critical" and "shields damaged" spam by adding a cooldown when shield health fluctuates around the threshold.