### PR TITLE
Keep hull health above zero to get DMX on damage

### DIFF
--- a/src/integrations/emptyepsilon/client.ts
+++ b/src/integrations/emptyepsilon/client.ts
@@ -27,6 +27,7 @@ const LandingPadStateToText = {
 export type AlertLevel = (typeof alertStates)[keyof typeof alertStates];
 export type EmptyEpsilonState = Record<string, any>;
 export type LandingPadState = (typeof LandingPadStates)[keyof typeof LandingPadStates];
+type EmptyEpsilonCommand = 'setSystemHealth' | 'setSystemHeat' | 'setWeaponStorage' | 'setLandingPadState';
 
 export class EmptyEpsilonClient {
 	private isEmulated: boolean;
@@ -152,10 +153,14 @@ export class EmptyEpsilonClient {
 		const hullMaxHealth = get(this.previousState, 'general.shipHullMax');
 		if (hullMaxHealth === undefined) throw new Error('No hull max health available');
 		const healthPointValue = Math.floor(hullHealthPercent * hullMaxHealth);
-		const url = `${this.setUrl}?setHull("${healthPointValue}")`;
+		return this.setHullHealthPoints(healthPointValue);
+	}
+
+	public setHullHealthPoints(hullHealthPoints: number) {
+		const url = `${this.setUrl}?setHull("${hullHealthPoints}")`;
 		return axios.get(url).then(res => {
 			if (get(res, 'data.ERROR')) throw new Error(res.data.ERROR);
-			logger.success(`Ship hull health set to ${healthPointValue}`);
+			logger.success(`Ship hull health set to ${hullHealthPoints}`);
 		});
 	}
 
@@ -168,7 +173,7 @@ export class EmptyEpsilonClient {
 		});
 	}
 
-	public setGameState(command: string, target: string, value: any) {
+	public setGameState(command: EmptyEpsilonCommand, target: string, value: any) {
 		const isEeConnectionEnabled = !!get(getData('ship', 'metadata'), 'ee_connection_enabled');
 		if (!isEeConnectionEnabled) {
 			logger.warn('setGameState was called while Backend <-> EE connection is disabled', { command, target, value });

--- a/src/rules/ship/autoRepairHull.ts
+++ b/src/rules/ship/autoRepairHull.ts
@@ -1,0 +1,27 @@
+import { getEmptyEpsilonClient } from '@/integrations/emptyepsilon/client';
+import { logger } from '@/logger';
+import { watch } from '@/store/store';
+import { throttle } from 'lodash';
+
+const THROTTLE_INTERVAL_MS = 2000;
+
+async function repairHull(health: number) {
+	const client = getEmptyEpsilonClient();
+	await client.setHullHealthPoints(health);
+}
+
+const repairHullThrottled = throttle(repairHull, THROTTLE_INTERVAL_MS);
+
+// Keep hull at above 0 health so that the next hit will cause the hull damage DMX to be triggered
+async function autoRepairHull(current: Record<string, any>, previous: Record<string, any>) {
+	const hullHealth = current?.general?.shipHull;
+	if (typeof hullHealth !== 'number') return;
+	if (hullHealth < 1) {
+		logger.info(`Hull health is ${hullHealth}, repairing to 1 health...`);
+		await repairHullThrottled(1);
+	} else {
+		repairHullThrottled.cancel();
+	}
+}
+
+watch(['data', 'ship', 'ee'], autoRepairHull);


### PR DESCRIPTION
When EmptyEpsilon hull health drops below one set it to one, so that following hits to Odysseus will trigger the hull damage DMX.

Ensure that we don't break any tasks when hull health fluctuates between 0 and 1.