### PR TITLE
Auto-depressurize hangar bay when fighters are launched

### DIFF
--- a/db/redux/box/airlock.js
+++ b/db/redux/box/airlock.js
@@ -16,17 +16,27 @@ blobs.push({
 	config: {
 		title_bar_text: 'Hangar Bay', // shown in an extra bar at the top of the UI, if set
 		allow_depressurize: false,    // should the depressurize button be shown in the player UI?
+		fighter_launch_delay: 30000,  // milliseconds before depressurization starts on fighter launch
 		jump_close_delay: 42000,      // milliseconds before door closes after jump initiation
-		auto_close_delay: 15000,      // milliseconds before door closes automatically after opening (0 = never)
+		auto_close_delay: 0,          // milliseconds before door closes automatically after opening (0 = never)
+		// auto-depressurize when any fighters are launched
+		fighter_pads: ['landingPadStatus1', 'landingPadStatus2', 'landingPadStatus3'],
 		// DMX events to fire on transition start
 		dmx_events: {
 			open: 'HangarBayDoorUnlock',
 			close: 'HangarBayDoorLock',
+			fighter_launch: 'HangarBayDepressurizeWarning',
+			depressurize: 'HangarBayDepressurize',
+			pressurize: 'HangarBayPressurize',
 		},
 		// custom transition durations (milliseconds)
-		transition_times: {},
+		transition_times: {
+			depressurize: 10000  // activated automatically when fighters are launched
+		},
 		// custom UI strings
-		messages: {},
+		messages: {
+			status_vacuum: 'Fighters on mission',
+		},
 	},
 });
 

--- a/src/dmx.ts
+++ b/src/dmx.ts
@@ -132,6 +132,9 @@ export const CHANNELS = {
 	MainAirlockDepressurizeFast: 289,
 	HangarBayDoorLock: 195,
 	HangarBayDoorUnlock: 196,
+	HangarBayFighterLaunch: 197,
+	HangarBayDepressurize: 198,
+	HangarBayPressurize: 199,
 
 	__SHIP_NOTIFICATIONS__: 0,
 	LoraBeaconSignalDecrypted: 250,

--- a/src/rules/boxes/airlock.js
+++ b/src/rules/boxes/airlock.js
@@ -2,7 +2,7 @@ import { store, watch } from '@/store/store';
 import { CHANNELS, fireEvent } from '@/dmx';
 import { logger } from '@/logger';
 import { saveBlob, clamp, timeout } from '../helpers';
-import {LandingPadStates} from "@/integrations/emptyepsilon/client";
+import { LandingPadStates } from "@/integrations/emptyepsilon/client";
 
 const airlockNames = ['airlock_main', 'airlock_hangarbay'];
 
@@ -31,7 +31,7 @@ function Airlock(airlockName) {
 	this.commandCounter = 0;
 	this.closeBeforeJumpTimeout = null;
 	this.fighterLaunchTimeout = null;
-	this.landingPads = {};
+	this.eeLandingPadStatus = {};
 
 	watch(['data', 'box', this.name], (data) => {
 		this.data = data;
@@ -58,7 +58,7 @@ function Airlock(airlockName) {
 	});
 
 	watch(['data', 'ship', 'ee', 'landingPads'], (landingPads) => {
-		this.landingPads = landingPads;
+		this.eeLandingPadStatus = landingPads || {};
 		this.depressurizeIfFightersLaunched();
 	});
 
@@ -169,7 +169,7 @@ Airlock.prototype = {
 	},
 	fightersLaunched() {
 		const fighterPads = this.data.config?.fighter_pads || [];
-		const padStatus = this.landingPads || {};
+		const padStatus = this.eeLandingPadStatus || {};
 		return fighterPads.some(padName => padStatus[padName] === LandingPadStates.Launched);
 	},
 

--- a/src/rules/boxes/airlock.js
+++ b/src/rules/boxes/airlock.js
@@ -2,6 +2,7 @@ import { store, watch } from '@/store/store';
 import { CHANNELS, fireEvent } from '@/dmx';
 import { logger } from '@/logger';
 import { saveBlob, clamp, timeout } from '../helpers';
+import {LandingPadStates} from "@/integrations/emptyepsilon/client";
 
 const airlockNames = ['airlock_main', 'airlock_hangarbay'];
 
@@ -29,10 +30,13 @@ function Airlock(airlockName) {
 	this.data = store.getState().data.box[airlockName] || {};
 	this.commandCounter = 0;
 	this.closeBeforeJumpTimeout = null;
+	this.fighterLaunchTimeout = null;
+	this.landingPads = {};
 
 	watch(['data', 'box', this.name], (data) => {
 		this.data = data;
 		if (data?.command) this.command(data.command);
+		this.depressurizeIfFightersLaunched();
 	});
 
 	watch(['data', 'ship', 'jump'], (current, previous) => {
@@ -51,6 +55,11 @@ function Airlock(airlockName) {
 		if (current.status === JUMPING && previous.status !== JUMPING) {
 			this.patchData({ status: 'closed', pressure: 1.0, command: 'stop' })
 		}
+	});
+
+	watch(['data', 'ship', 'ee', 'landingPads'], (landingPads) => {
+		this.landingPads = landingPads;
+		this.depressurizeIfFightersLaunched();
 	});
 
 	// If the backend was stopped in the middle of an uninterruptible airlock transition (e.g. pressurize), the airlock
@@ -88,7 +97,8 @@ Airlock.prototype = {
 			pressurize: ['pressurize'],
 			open: ['pressurize', 'openDoor', 'autoClose'],
 			depressurize: ['closeDoor', 'depressurize', 'autoPressurize'],
-			forceDepressurize: ['denyAccess', 'closeDoor', 'depressurize', 'autoPressurize', 'allowAccess'],
+			fighterLaunch: ['denyAccess', 'closeDoor', 'depressurize', 'allowAccess'],  // for hangar bay
+			forceDepressurize: ['denyAccess', 'closeDoor', 'depressurize', 'autoPressurize', 'allowAccess'], // access override for special scene
 			evacuate: ['closeDoor', 'evacuate', 'autoPressurize'], // faster depressurize for jettisoning objects
 			close: ['closeDoor'],
 			stop: ['stopTransition'],  // also used to force status
@@ -134,6 +144,33 @@ Airlock.prototype = {
 		if (status !== 'closed' && status !== 'closing') {
 			this.command('close');
 		}
+	},
+
+	// Trigger automatic depressurization when fighters are launched:
+	depressurizeIfFightersLaunched() {
+		const fightersLaunched = this.fightersLaunched();
+		const status = this.data.status;
+		if (fightersLaunched) {
+			if (status !== 'vacuum' && status !== 'depressurizing' && !this.fighterLaunchTimeout) {
+				const delay = this.data.config?.fighter_launch_delay || 20000; // Give players time to leave the hangar bay
+				logger.info(`Airlock ${this.name} detected fighter launch, depressurizing in ${delay} ms`);
+				this.dmx('fighter_launch');  // Play warning sound
+				this.fighterLaunchTimeout = setTimeout(() => this.command('fighterLaunch'), delay);
+			}
+		} else {
+			if (this.fighterLaunchTimeout) clearTimeout(this.fighterLaunchTimeout);
+			this.fighterLaunchTimeout = null;
+			if (status === 'vacuum' || status === 'depressurizing') {
+				logger.info(`Airlock ${this.name} detected all fighters returned, pressurizing`);
+				// KLUGE: Just doing this.command('pressurize') apparently triggers an infinite loop!
+				this.patchData({ status: 'pressurizing', command: 'pressurize' });
+			}
+		}
+	},
+	fightersLaunched() {
+		const fighterPads = this.data.config?.fighter_pads || [];
+		const padStatus = this.landingPads || {};
+		return fighterPads.some(padName => padStatus[padName] === LandingPadStates.Launched);
 	},
 
 	// transition animations
@@ -194,19 +231,26 @@ Airlock.prototype = {
 		const status = this.data.status;
 		if (status === 'closed') return;  // already closed
 
-		const startTime = now();
-		const endTime = startTime + this.transitionTime('close');
-		logger.debug(`Airlock ${this.name} closing from ${startTime} to ${endTime}`);
-
 		// This method may be called when jumping even if the airlock is fully or partially depressurized.
 		// In that case we stop any pressure change in progress but leave the pressure at its current value.
 		// A "stop" command will be automatically issued on successful jump, resetting the pressure to 1.0.
-		const pressure = clamp(this.getPressure() || 0.0, 0, 1);
+		const currentPressure = clamp(this.getPressure() || 0.0, 0, 1);
 
-		this.dmx('close');
-		this.patchData({ status: 'closing', countdown_to: endTime, pressure: pressure });
-		await this.waitUntil(endTime);
-		this.patchData({ status: 'closed', countdown_to: 0, pressure: pressure });
+		if (status === 'closing') {
+			// We might get here e.g. if an automatic close due to fighter launch interrupts a manual close.
+			// In that case we just wait out the remaining countdown.
+			await this.waitUntil(this.data.countdown_to || 0);
+		} else {
+			const startTime = now();
+			const endTime = startTime + this.transitionTime('close');
+			logger.debug(`Airlock ${this.name} closing from ${startTime} to ${endTime}`);
+
+			this.dmx('close');
+			this.patchData({ status: 'closing', countdown_to: endTime, pressure: currentPressure });
+			await this.waitUntil(endTime);
+		}
+
+		this.patchData({ status: 'closed', countdown_to: 0, pressure: currentPressure });
 	},
 	async autoClose() {
 		const config = this.data.config || DEFAULT_CONFIG, status = this.data.status;


### PR DESCRIPTION
Note: I'm tentatively reusing DMX channels 197-199, which were allocated for hangar bay events in 2019 and unused in 2024 runs 1 & 2. I've already noted these in the sound design master file.